### PR TITLE
Implement Dexter action acknowledgement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2366,15 +2366,35 @@ fn process_new_messages(
                     let via_staff = new_msg.text.text().starts_with(staffs_tag);
                     let from_dexter = from.eq_ignore_ascii_case("Dexter");
 
-                    // Allow Dexter to send PMs on our behalf
+                    // Allow Dexter to send action messages on our behalf
                     if from_dexter && pm_to_me {
+                        let mut success = true;
                         if let Some(captures) = PM_RGX.captures(&msg) {
                             let target = captures[1].trim_start_matches('@').to_owned();
                             let pm_msg = captures[2].to_owned();
                             if !target.is_empty() {
                                 let _ = tx.send(PostType::Post(pm_msg, Some(target)));
+                            } else {
+                                success = false;
                             }
+                        } else if let Some(rest) = msg.strip_prefix("/m ") {
+                            if !rest.is_empty() {
+                                let _ = tx.send(PostType::Post(rest.to_owned(), Some(SEND_TO_MEMBERS.to_owned())));
+                            } else {
+                                success = false;
+                            }
+                        } else if let Some(rest) = msg.strip_prefix("/s ") {
+                            if !rest.is_empty() {
+                                let _ = tx.send(PostType::Post(rest.to_owned(), Some(SEND_TO_STAFFS.to_owned())));
+                            } else {
+                                success = false;
+                            }
+                        } else {
+                            success = false;
                         }
+
+                        let ack = if success { "👍️" } else { "👎️" };
+                        let _ = tx.send(PostType::Post(ack.to_owned(), Some("Dexter".to_owned())));
                     }
 
                     if (pm_to_me && !from_dexter)


### PR DESCRIPTION
## Summary
- allow Dexter to send action messages to Dasho when logged in as Dasho
- after processing Dexter's `/pm`, `/m`, or `/s` actions, queue a 👍️ or 👎️ PM back to Dexter depending on success

## Testing
- `cargo test`