### PR TITLE
Add staff tag shortcut

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1535,6 +1535,8 @@ impl LeChatPHPClient {
             {
                 if text.text().starts_with(&app.members_tag) {
                     app.input = format!("/m @{} ", username);
+                } else if text.text().starts_with(&app.staffs_tag) {
+                    app.input = format!("/s @{} ", username);
                 } else {
                     app.input = format!("@{} ", username);
                 }


### PR DESCRIPTION
## Summary
- allow tagging staff channel messages

## Testing
- `cargo build --quiet`
- `cargo test --quiet`