### PR TITLE
Add Dexter-specific Shift+M behavior

### DIFF
--- a/CMDS.md
+++ b/CMDS.md
@@ -29,6 +29,6 @@
 - `Shift+Y` copy first link in message
 - `m` toggle notifications
 - `Shift+G` guest view
-- `Shift+M` members view
+- `Shift+M` members view (Dexter: show PMs from Dasho)
 - `Ctrl+D`/`PageDown` scroll down
 - `Ctrl+U`/`PageUp` scroll up

--- a/src/main.rs
+++ b/src/main.rs
@@ -1061,7 +1061,7 @@ impl LeChatPHPClient {
                 code: KeyCode::Char('M'),
                 modifiers: KeyModifiers::SHIFT,
                 ..
-            } => self.handle_normal_mode_key_event_toggle_member_view(),
+            } => self.handle_normal_mode_key_event_shift_m(app, messages),
             KeyEvent {
                 code: KeyCode::Char('G'),
                 modifiers: KeyModifiers::SHIFT,
@@ -1522,6 +1522,51 @@ impl LeChatPHPClient {
 
     fn handle_normal_mode_key_event_toggle_member_view(&mut self) {
         self.display_member_view = !self.display_member_view;
+    }
+
+    fn handle_normal_mode_key_event_shift_m(
+        &mut self,
+        app: &mut App,
+        messages: &Arc<Mutex<Vec<Message>>>,
+    ) {
+        if self
+            .base_client
+            .username
+            .eq_ignore_ascii_case("Dexter")
+        {
+            let msgs = messages.lock().unwrap();
+            let mut lines = Vec::new();
+            for m in msgs.iter() {
+                let txt = m.text.text();
+                if !txt.starts_with(&self.config.members_tag) {
+                    continue;
+                }
+                if let Some((from, to_opt, _)) = get_message(&m.text, &self.config.members_tag) {
+                    let to_is_dexter = to_opt
+                        .as_ref()
+                        .map(|t| t.eq_ignore_ascii_case("Dexter"))
+                        .unwrap_or(false);
+                    if from.eq_ignore_ascii_case("Dasho") && to_is_dexter {
+                        lines.push(format!("{} - {}", m.date, txt));
+                    }
+                }
+            }
+
+            if !lines.is_empty() {
+                let all = lines.join("\n");
+                let msg = Message::new(
+                    None,
+                    MessageType::UserMsg,
+                    String::new(),
+                    None,
+                    StyledText::Text(all),
+                );
+                app.long_message = Some(msg);
+                app.input_mode = InputMode::LongMessage;
+            }
+        } else {
+            self.handle_normal_mode_key_event_toggle_member_view();
+        }
     }
 
     fn handle_normal_mode_key_event_g(&mut self, app: &mut App) {


### PR DESCRIPTION
## Summary
- implement `handle_normal_mode_key_event_shift_m` to display Dasho PMs when Dexter is logged in
- map `Shift+M` to the new handler
- document Dexter behaviour for `Shift+M`

## Testing
- `cargo test`